### PR TITLE
IP 주소 관련 버그 수정

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -231,7 +231,7 @@ $board_table_main_schema = "
 
     memo text,
 
-    ip char(15),
+    ip char(100),
     password char(41),
     name char(20) not null,
     homepage char(255),
@@ -288,7 +288,7 @@ $board_comment_schema = "
     name char(20),
     password char(41),
     memo text,
-    ip char(15),
+    ip char(100),
     reg_date int(13),
 
     KEY parent (parent)


### PR DESCRIPTION
IPv6으로 접속하거나, 로컬호스트로 접속 시 가끔 IP가 127.0.0.1 대신 ::ffff:127.0.0.1로 뜨는 경우가 있는데 이때 IP 주소 필드 글자 수 제한 초과로 오류가 나는 현상을 수정하였습니다.